### PR TITLE
Service: Cache

### DIFF
--- a/cache/purge_request.go
+++ b/cache/purge_request.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+type PurgeRequest struct {
+	Domain string   `validate:"required_without=URL"`
+	URL    []string `validate:"required_without=Domain"`
+}

--- a/cache/purge_service.go
+++ b/cache/purge_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Purge(req *PurgeRequest) error {
+	return s.PurgeWithContext(context.Background(), req)
+}
+
+func (s *Service) PurgeWithContext(ctx context.Context, req *PurgeRequest) error {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return err
+	}
+	client := webaccel.NewOp(s.client)
+
+	switch {
+	case len(req.URL) > 0:
+		_, err := client.DeleteCache(ctx, &webaccel.DeleteCacheRequest{URL: req.URL})
+		return err
+	case req.Domain != "":
+		return client.DeleteAllCache(ctx, &webaccel.DeleteAllCacheRequest{Domain: req.Domain})
+	default:
+		return fmt.Errorf("invalid request: %v", req) // 到達しない
+	}
+}

--- a/cache/service.go
+++ b/cache/service.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"github.com/sacloud/services"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+// Service provides a high-level API of for Service
+type Service struct {
+	client *webaccel.Client
+}
+
+var _ services.Service = (*Service)(nil)
+
+// New returns new site instance of Service
+func New(client *webaccel.Client) *Service {
+	return &Service{client: client}
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "cache",
+	}
+}
+
+func (s *Service) Operations() services.Operations {
+	return []services.SupportedOperation{
+		{Name: "purge", OperationType: services.OperationTypeAction},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{}
+}

--- a/cache/service_test.go
+++ b/cache/service_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/packages-go/testutil"
+	"github.com/sacloud/webaccel-api-go"
+	"github.com/stretchr/testify/require"
+)
+
+var caller = &webaccel.Client{Options: &client.Options{UserAgent: "webaccel-service-go/v" + webaccel.Version}}
+
+// TestService_CRUD_plus_L CRUD+L
+func TestService_CRUD_plus_L(t *testing.T) {
+	if !testutil.IsAccTest() {
+		t.Skip("environment variables required: TESTACC")
+	}
+	testutil.PreCheckEnvsFunc(
+		"SAKURACLOUD_ACCESS_TOKEN",
+		"SAKURACLOUD_ACCESS_TOKEN_SECRET",
+		"SAKURACLOUD_WEBACCEL_DOMAIN",
+		"SAKURACLOUD_WEBACCEL_URLS",
+	)(t)
+	svc := New(caller)
+
+	t.Run("Purge with invalid parameter returns error", func(t *testing.T) {
+		err := svc.Purge(&PurgeRequest{})
+		require.Error(t, err)
+	})
+
+	t.Run("Purge by URLs", func(t *testing.T) {
+		urls := strings.Split(os.Getenv("SAKURACLOUD_WEBACCEL_URLS"), ",")
+		err := svc.Purge(&PurgeRequest{URL: urls})
+		require.NoError(t, err)
+	})
+
+	t.Run("Purge by Domain", func(t *testing.T) {
+		domain := os.Getenv("SAKURACLOUD_WEBACCEL_DOMAIN")
+		err := svc.Purge(&PurgeRequest{Domain: domain})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
キャッシュ操作

ウェブアクセラレータAPIとしてはDeleteCache or DeleteAllCacheだが、sacloud/servicesの文脈ではDelete操作はIDを受け取る操作となっており、混同を避けるためにfunc名をDeleteではなくPurgeとした。

また、受け取ったパラメータ次第でDeleteCacheとDeleteAllCacheのどちらを呼び出すのか判断するようにした。