### PR TITLE
Service: Certificate

### DIFF
--- a/certificate/create_request.go
+++ b/certificate/create_request.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"github.com/sacloud/webaccel-api-go"
+)
+
+type CreateRequest struct {
+	SiteId string `service:"-" validate:"required"`
+
+	CertificateChain string `validate:"required"`
+	Key              string `validate:"required"`
+}
+
+func (req *CreateRequest) ToRequestParameter() *webaccel.CreateOrUpdateCertificateRequest {
+	return &webaccel.CreateOrUpdateCertificateRequest{
+		CertificateChain: req.CertificateChain,
+		Key:              req.Key,
+	}
+}

--- a/certificate/create_service.go
+++ b/certificate/create_service.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Create(req *CreateRequest) (*webaccel.Certificates, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*webaccel.Certificates, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+	client := webaccel.NewOp(s.client)
+	cert, err := client.ReadCertificate(ctx, req.SiteId)
+	if err != nil {
+		return nil, err
+	}
+
+	if cert != nil && cert.Current != nil {
+		return client.UpdateCertificate(ctx, req.SiteId, req.ToRequestParameter())
+	}
+	return client.CreateCertificate(ctx, req.SiteId, req.ToRequestParameter())
+}

--- a/certificate/find_request.go
+++ b/certificate/find_request.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+type FindRequest struct {
+	SiteId string `service:"-" validate:"required"`
+}

--- a/certificate/find_service.go
+++ b/certificate/find_service.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*webaccel.Certificates, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*webaccel.Certificates, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+
+	client := webaccel.NewOp(s.client)
+	cert, err := client.ReadCertificate(ctx, req.SiteId)
+	if err != nil {
+		if webaccel.IsNotFoundError(err) {
+			// 通常は証明書が登録されていない場合でも200となるためここには到達しないはず
+			return []*webaccel.Certificates{}, nil
+		}
+		return nil, err
+	}
+	return []*webaccel.Certificates{cert}, nil
+}

--- a/certificate/read_request.go
+++ b/certificate/read_request.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+type ReadRequest struct {
+	Id     string `service:"-" validate:"required"`
+	SiteId string `service:"-" validate:"required"`
+}

--- a/certificate/read_service.go
+++ b/certificate/read_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Read(req *ReadRequest) (*webaccel.Certificates, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*webaccel.Certificates, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+
+	client := webaccel.NewOp(s.client)
+	cert, err := client.ReadCertificate(ctx, req.SiteId)
+	if err != nil {
+		return nil, err
+	}
+	if cert.Current != nil && cert.Current.ID == req.Id {
+		return cert, nil
+	}
+
+	return nil, webaccel.NewAPIError(http.MethodGet, nil, http.StatusNotFound, nil)
+}

--- a/certificate/service.go
+++ b/certificate/service.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"github.com/sacloud/services"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+// Service provides a high-level API of for Service
+type Service struct {
+	client *webaccel.Client
+}
+
+var _ services.Service = (*Service)(nil)
+
+// New returns new site instance of Service
+func New(client *webaccel.Client) *Service {
+	return &Service{client: client}
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "certificate",
+	}
+}
+
+func (s *Service) Operations() services.Operations {
+	return []services.SupportedOperation{
+		{Name: "find", OperationType: services.OperationTypeList},
+		{Name: "read", OperationType: services.OperationTypeRead},
+		{Name: "create", OperationType: services.OperationTypeCreate},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{}
+}

--- a/certificate/service_test.go
+++ b/certificate/service_test.go
@@ -1,0 +1,81 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"os"
+	"testing"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/packages-go/testutil"
+	"github.com/sacloud/webaccel-api-go"
+	"github.com/stretchr/testify/require"
+)
+
+var caller = &webaccel.Client{Options: &client.Options{UserAgent: "webaccel-service-go/v" + webaccel.Version}}
+
+// TestService_CRUD_plus_L CRUD+L
+//
+// Note: 実行時にサイトが1件以上登録済みであること
+func TestService_CRUD_plus_L(t *testing.T) {
+	if !testutil.IsAccTest() {
+		t.Skip("environment variables required: TESTACC")
+	}
+	testutil.PreCheckEnvsFunc(
+		"SAKURACLOUD_ACCESS_TOKEN",
+		"SAKURACLOUD_ACCESS_TOKEN_SECRET",
+		"SAKURACLOUD_WEBACCEL_SITE_ID",
+	)(t)
+	svc := New(caller)
+
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	var certId string
+
+	t.Run("List", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{SiteId: siteId})
+		require.NoError(t, err)
+		require.NotEmpty(t, found)
+
+		if found[0].Current != nil {
+			certId = found[0].Current.ID
+		}
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		if certId == "" {
+			t.Skip("cert is empty, skip.")
+		}
+		read, err := svc.Read(&ReadRequest{SiteId: siteId, Id: certId})
+		require.NoError(t, err)
+		require.NotEmpty(t, read)
+		require.Equal(t, certId, read.Current.ID)
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		crt := os.Getenv("SAKURACLOUD_WEBACCEL_CERT")
+		key := os.Getenv("SAKURACLOUD_WEBACCEL_KEY")
+		if crt == "" || key == "" {
+			t.Skip("SAKURACLOUD_WEBACCEL_CERT or SAKURACLOUD_WEBACCEL_KEY is empty, skip.")
+		}
+		created, err := svc.Create(&CreateRequest{
+			SiteId:           siteId,
+			CertificateChain: crt,
+			Key:              key,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, created)
+		require.NotEmpty(t, created.Current)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/sacloud/api-client-go v0.1.0
 	github.com/sacloud/packages-go v0.0.3
 	github.com/sacloud/services v0.0.2-0.20220422071454-6b9a0bc8caf8
-	github.com/sacloud/webaccel-api-go v1.1.1
+	github.com/sacloud/webaccel-api-go v1.1.3-0.20220523074054-dbb0dea80b17
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/sacloud/packages-go v0.0.3 h1:MtUVkZyAwvr3drjjTj4PKssRrm3hRGWPdEj+skI
 github.com/sacloud/packages-go v0.0.3/go.mod h1:Eny1qnbKr9n/5yfXDiwOC+0YMiBhK1HBYGjjmxes+CI=
 github.com/sacloud/services v0.0.2-0.20220422071454-6b9a0bc8caf8 h1:xlAcHj6ebeOUu5pigHvM9H1tArroiSMEj7BUnuGKOP0=
 github.com/sacloud/services v0.0.2-0.20220422071454-6b9a0bc8caf8/go.mod h1:iKmGnTl+oBZzOz44nz5HGsa+xmY1YnIblwijAih6KmQ=
-github.com/sacloud/webaccel-api-go v1.1.1 h1:rBwt0/2/BnKFMHEe2cD4b2WKqbXkGyOigztCdr/worA=
-github.com/sacloud/webaccel-api-go v1.1.1/go.mod h1:GThzM8mxWVw4acwRQFDJOIIlBl2+l2Ciav8vD697zeQ=
+github.com/sacloud/webaccel-api-go v1.1.3-0.20220523074054-dbb0dea80b17 h1:vNdNvVLtFD8KhviB6Uu3JsaaEM9CPqFkZgNn6ve2cYo=
+github.com/sacloud/webaccel-api-go v1.1.3-0.20220523074054-dbb0dea80b17/go.mod h1:GThzM8mxWVw4acwRQFDJOIIlBl2+l2Ciav8vD697zeQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Note: Createについては、対象サイトに証明書登録があればUpdate、以外はCreateを呼ぶように実装。

CreateOrUpdateのような名前にしてもよかったが、シグニチャがsacloud/servicesのCreate互換(ID不要、戻り値は単体)であることからCreateという名前を採用した。