### PR TITLE
Service: Usage

### DIFF
--- a/usage/find_request.go
+++ b/usage/find_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import "fmt"
+
+type FindRequest struct {
+	Year  int `validate:"required_with=Month"`
+	Month int `validate:"required_with=Year,omitempty,min=1,max=12"`
+}
+
+func (req *FindRequest) targetYM() string {
+	if req.Year == 0 || req.Month == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d%02d", req.Year, req.Month)
+}

--- a/usage/find_request_test.go
+++ b/usage/find_request_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import (
+	"testing"
+
+	"github.com/sacloud/services/helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindRequest_validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *FindRequest
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			req:     &FindRequest{},
+			wantErr: false,
+		},
+		{
+			name:    "returns error with only Year",
+			req:     &FindRequest{Year: 1},
+			wantErr: true,
+		},
+		{
+			name:    "returns error with only Month",
+			req:     &FindRequest{Month: 1},
+			wantErr: true,
+		},
+		{
+			name:    "valid",
+			req:     &FindRequest{Year: 2020, Month: 1},
+			wantErr: false,
+		},
+		{
+			name:    "returns error with invalid month",
+			req:     &FindRequest{Year: 2020, Month: -1},
+			wantErr: true,
+		},
+		{
+			name:    "returns error with multiple error",
+			req:     &FindRequest{Year: 0, Month: -1},
+			wantErr: true,
+		},
+	}
+
+	svc := New(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := helper.ValidateStruct(svc, tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/usage/find_service.go
+++ b/usage/find_service.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import (
+	"context"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*Monthly, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*Monthly, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+
+	client := webaccel.NewOp(s.client)
+	found, err := client.MonthlyUsage(ctx, req.targetYM())
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*Monthly
+	for i := range found.MonthlyUsages {
+		results = append(results, &Monthly{
+			Year:         found.Year,
+			Month:        found.Month,
+			MonthlyUsage: *found.MonthlyUsages[i],
+		})
+	}
+	return results, nil
+}

--- a/usage/monthly.go
+++ b/usage/monthly.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import "github.com/sacloud/webaccel-api-go"
+
+type Monthly struct {
+	Year  int
+	Month int
+	webaccel.MonthlyUsage
+}

--- a/usage/service.go
+++ b/usage/service.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import (
+	"github.com/sacloud/services"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+// Service provides a high-level API of for Service
+type Service struct {
+	client *webaccel.Client
+}
+
+var _ services.Service = (*Service)(nil)
+
+// New returns new site instance of Service
+func New(client *webaccel.Client) *Service {
+	return &Service{client: client}
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "site",
+	}
+}
+
+func (s *Service) Operations() services.Operations {
+	return []services.SupportedOperation{
+		{Name: "find", OperationType: services.OperationTypeList},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{}
+}

--- a/usage/service_test.go
+++ b/usage/service_test.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import (
+	"testing"
+	"time"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/packages-go/testutil"
+	"github.com/sacloud/webaccel-api-go"
+	"github.com/stretchr/testify/require"
+)
+
+var caller = &webaccel.Client{Options: &client.Options{UserAgent: "webaccel-service-go/v" + webaccel.Version}}
+
+// TestService_CRUD_plus_L CRUD+L
+//
+// Note: 実行時にサイトが1件以上登録済みであること
+func TestService_CRUD_plus_L(t *testing.T) {
+	if !testutil.IsAccTest() {
+		t.Skip("environment variables required: TESTACC")
+	}
+	testutil.PreCheckEnvsFunc(
+		"SAKURACLOUD_ACCESS_TOKEN",
+		"SAKURACLOUD_ACCESS_TOKEN_SECRET",
+	)(t)
+	svc := New(caller)
+
+	t.Run("List", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, found)
+		if len(found) > 0 {
+			require.NotEmpty(t, found[0].MonthlyUsage)
+
+			now := time.Now() // yearとmonthを省略した場合は当月となるはず
+			require.Equal(t, now.Year(), found[0].Year)
+			require.Equal(t, now.Month(), time.Month(found[0].Month))
+		}
+	})
+}


### PR DESCRIPTION
Note: 元の(webaccel-api-goの)MonthlyUsageはYear/Monthに対し複数のサイトの情報がぶら下がる形となっている。

```go
// MonthlyUsageResults 月別使用量
type MonthlyUsageResults struct {
	Year          int
	Month         int
	MonthlyUsages []*MonthlyUsage
}
```

これをラップして以下のようなstructを提供し、サービスAPIの戻り値として利用する。

```go
type Monthly struct {
	Year  int
	Month int
	webaccel.MonthlyUsage
}
```