### PR TITLE
ACL機能

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/sacloud/api-client-go v0.2.10
 	github.com/sacloud/packages-go v0.0.10
 	github.com/sacloud/services v0.0.2-0.20220422071454-6b9a0bc8caf8
-	github.com/sacloud/webaccel-api-go v1.1.6
+	github.com/sacloud/webaccel-api-go v1.2.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/sacloud/packages-go v0.0.10 h1:UiQGjy8LretewkRhsuna1TBM9Vz/l9FoYpQx+D
 github.com/sacloud/packages-go v0.0.10/go.mod h1:f8QITBh9z4IZc4yE9j21Q8b0sXEMwRlRmhhjWeDVTYs=
 github.com/sacloud/services v0.0.2-0.20220422071454-6b9a0bc8caf8 h1:xlAcHj6ebeOUu5pigHvM9H1tArroiSMEj7BUnuGKOP0=
 github.com/sacloud/services v0.0.2-0.20220422071454-6b9a0bc8caf8/go.mod h1:iKmGnTl+oBZzOz44nz5HGsa+xmY1YnIblwijAih6KmQ=
-github.com/sacloud/webaccel-api-go v1.1.6 h1:OjAORCUzk3kYCXSPsHj7D0+wk9/ILzZsbqPTtk24j4A=
-github.com/sacloud/webaccel-api-go v1.1.6/go.mod h1:xzeJjXIBtkjWc75u5gihiScjBlEBhxfLL60bhsHJSB4=
+github.com/sacloud/webaccel-api-go v1.2.0 h1:eoiMNmz9bbeL3Ht1WPLKe2DbG7vH7Lb3a/jCmSjcKPs=
+github.com/sacloud/webaccel-api-go v1.2.0/go.mod h1:ZgTg5TldLf90RU9y3TnI0/luxERkJofk9+iLaupKB2E=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/site/acl/create_request.go
+++ b/site/acl/create_request.go
@@ -1,0 +1,21 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+type CreateRequest struct {
+	SiteId string `service:"-" validate:"required"`
+
+	ACL string `validate:"required"`
+}

--- a/site/acl/create_service.go
+++ b/site/acl/create_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"context"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Create(req *CreateRequest) (*webaccel.ACLResult, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*webaccel.ACLResult, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+	client := webaccel.NewOp(s.client)
+	return client.UpsertACL(ctx, req.SiteId, req.ACL)
+}

--- a/site/acl/delete_request.go
+++ b/site/acl/delete_request.go
@@ -1,0 +1,19 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+type DeleteRequest struct {
+	SiteId string `service:"-" validate:"required"`
+}

--- a/site/acl/delete_service.go
+++ b/site/acl/delete_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"context"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return err
+	}
+	client := webaccel.NewOp(s.client)
+	return client.DeleteACL(ctx, req.SiteId)
+}

--- a/site/acl/read_request.go
+++ b/site/acl/read_request.go
@@ -1,0 +1,19 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+type ReadRequest struct {
+	SiteId string `service:"-" validate:"required"`
+}

--- a/site/acl/read_service.go
+++ b/site/acl/read_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Read(req *ReadRequest) (*webaccel.ACLResult, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*webaccel.ACLResult, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+
+	client := webaccel.NewOp(s.client)
+	acl, err := client.ReadACL(ctx, req.SiteId)
+	if err != nil {
+		return nil, err
+	}
+	if acl != nil && acl.ACL != "" {
+		return acl, nil
+	}
+
+	return nil, webaccel.NewAPIError(http.MethodGet, nil, http.StatusNotFound, nil)
+}

--- a/site/acl/service.go
+++ b/site/acl/service.go
@@ -1,0 +1,52 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"github.com/sacloud/services"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+// Service provides a high-level API of for Service
+type Service struct {
+	client *webaccel.Client
+}
+
+var _ services.Service = (*Service)(nil)
+
+// New returns new site instance of Service
+func New(client *webaccel.Client) *Service {
+	return &Service{client: client}
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name:           "certificate",
+		ParentServices: []string{"site"},
+	}
+}
+
+func (s *Service) Operations() services.Operations {
+	return []services.SupportedOperation{
+		{Name: "create", OperationType: services.OperationTypeCreate},
+		{Name: "read", OperationType: services.OperationTypeRead},
+		{Name: "update", OperationType: services.OperationTypeUpdate},
+		{Name: "delete", OperationType: services.OperationTypeDelete},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{}
+}

--- a/site/acl/service_test.go
+++ b/site/acl/service_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"os"
+	"testing"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/packages-go/testutil"
+	"github.com/sacloud/webaccel-api-go"
+	"github.com/stretchr/testify/require"
+)
+
+var caller = &webaccel.Client{Options: &client.Options{UserAgent: "webaccel-service-go/v" + webaccel.Version}}
+
+// TestService_CRUD_plus_L CRUD+L
+//
+// Note: 実行時にサイトが1件以上登録済みであること
+func TestService_CRUD_plus_L(t *testing.T) {
+	if !testutil.IsAccTest() {
+		t.Skip("environment variables required: TESTACC")
+	}
+	testutil.PreCheckEnvsFunc(
+		"SAKURACLOUD_ACCESS_TOKEN",
+		"SAKURACLOUD_ACCESS_TOKEN_SECRET",
+		"SAKURACLOUD_WEBACCEL_SITE_ID",
+	)(t)
+	svc := New(caller)
+
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	t.Run("Create", func(t *testing.T) {
+		created, err := svc.Create(&CreateRequest{
+			SiteId: siteId,
+			ACL:    "deny 192.0.2.5/25\ndeny 198.51.100.0\nallow all",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "deny 192.0.2.5/25\ndeny 198.51.100.0\nallow all", created.ACL)
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		read, err := svc.Read(&ReadRequest{SiteId: siteId})
+
+		require.NoError(t, err)
+		require.Equal(t, "deny 192.0.2.5/25\ndeny 198.51.100.0\nallow all", read.ACL)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		updated, err := svc.Update(&UpdateRequest{
+			SiteId: siteId,
+			ACL:    "allow 192.0.2.5/25\nallow 198.51.100.0\ndeny all",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "allow 192.0.2.5/25\nallow 198.51.100.0\ndeny all", updated.ACL)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err := svc.Delete(&DeleteRequest{SiteId: siteId})
+		require.NoError(t, err)
+
+		_, err = svc.Read(&ReadRequest{SiteId: siteId})
+		require.Error(t, err) // 404 error
+	})
+}

--- a/site/acl/update_request.go
+++ b/site/acl/update_request.go
@@ -1,0 +1,21 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+type UpdateRequest struct {
+	SiteId string `service:"-" validate:"required"`
+
+	ACL string `validate:"required"`
+}

--- a/site/acl/update_service.go
+++ b/site/acl/update_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022-2023 The sacloud/webaccel-service-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"context"
+
+	"github.com/sacloud/services/helper"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func (s *Service) Update(req *UpdateRequest) (*webaccel.ACLResult, error) {
+	return s.UpdateWithContext(context.Background(), req)
+}
+
+func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*webaccel.ACLResult, error) {
+	if err := helper.ValidateStruct(s, req); err != nil {
+		return nil, err
+	}
+	client := webaccel.NewOp(s.client)
+	return client.UpsertACL(ctx, req.SiteId, req.ACL)
+}


### PR DESCRIPTION
Note: ACLはサイトと1対1で紐づくため本来はSite Serviceの中に吸収したかったが、互換性維持の観点から追加が難しそうだったため別Serviceとした。次バージョン以降で整理する。

テスト結果

```
--- PASS: TestService_CRUD_plus_L (0.94s)
    --- PASS: TestService_CRUD_plus_L/Create (0.27s)
    --- PASS: TestService_CRUD_plus_L/Read (0.09s)
    --- PASS: TestService_CRUD_plus_L/Update (0.15s)
    --- PASS: TestService_CRUD_plus_L/Delete (0.42s)
PASS
ok  	github.com/sacloud/webaccel-service-go/site/acl	1.104s
```